### PR TITLE
shebang fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 // const argv = require('yargs').argv
 
 const { spawn, spawnSync } = require('child_process')
-const [ pathToNode, pathToFile, ...commands ] = process.argv
+const [pathToNode, pathToFile, ...commands] = process.argv
 const blessed = require('blessed')
 
 const screen = blessed.screen({
@@ -12,9 +12,9 @@ const screen = blessed.screen({
 commands.forEach((command, index) => {
   const [cmd, ...args] = command.split(' ')
   const opts = {
-    height: `${(100/commands.length)}%`,
+    height: `${100 / commands.length}%`,
     width: '100%',
-    top: `${index*(100/commands.length)}%`,
+    top: `${index * (100 / commands.length)}%`,
     interactive: false,
     content: '',
     tags: true,
@@ -37,7 +37,7 @@ commands.forEach((command, index) => {
     screen.render()
   })
   x.on('close', code => {
-    log.log(`child process exited with code ${code}`);
+    log.log(`child process exited with code ${code}`)
     screen.render()
   })
 })


### PR DESCRIPTION
I was receiving an error when attempting to run `unite ...`:

`The file '/Users/josef/.config/yarn/bin/unite' specified the interpreter '/usr/bin/node', which is not an executable command.`

This is due to my node binary being installed elsewhere than `/usr/bin/node`. Modifying the shebang line to `#!/usr/bin/env node` has resolved my issue.

[Related Stack Overflow](https://stackoverflow.com/questions/33509816/what-exactly-does-usr-bin-env-node-do-at-the-beginning-of-node-files)